### PR TITLE
Delete theme picker

### DIFF
--- a/pages/Header.js
+++ b/pages/Header.js
@@ -17,31 +17,7 @@ export default function Header(props) {
           <h1>Kristopher Gates</h1>
           <h2>Software Developer</h2>
         </div>
-        <div className="flexcols spacearound heading__controls">
-          <form id="theme-picker">
-            <span>Color Theme</span>
-            <label>
-              <input
-                type="radio"
-                id="select-offwhite"
-                name="theme"
-                onChange={() => props.switchTheme("offwhite")}
-                checked={props.theme === "offwhite"}
-              />{" "}
-              Light
-            </label>
-            <label>
-              <input
-                type="radio"
-                id="select-blue"
-                name="theme"
-                onChange={() => props.switchTheme("blue")}
-                checked={props.theme === "blue"}
-              />{" "}
-              Blue
-            </label>
-          </form>
-        </div>
+        <div className="flexcols spacearound heading__controls"></div>
       </header>
     </>
   );


### PR DESCRIPTION
Deleting the theme picker for now as I think it's more professional to have it set to a theme than have a polish free (and non-OS theme  auto configured) theme picker control placed so prominently. Can revisit and reimplement but likely will wait for the new SPA.